### PR TITLE
입력 코드의 오류 감지 및 처리

### DIFF
--- a/src/main/java/com/example/SonamuProject/controller/TranslateController.java
+++ b/src/main/java/com/example/SonamuProject/controller/TranslateController.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import java.io.FileNotFoundException;
+import java.io.UnsupportedEncodingException;
+
 @Controller
 public class TranslateController {
 
@@ -18,7 +21,7 @@ public class TranslateController {
     }
 
     @PostMapping("/translate")
-    public String translate(Model model, SourceCode sourceCode) {
+    public String translate(Model model, SourceCode sourceCode) throws FileNotFoundException, UnsupportedEncodingException {
         String output = translateService.translate(sourceCode);
         model.addAttribute("source", sourceCode.getCode());
         model.addAttribute("sourceType", sourceCode.getTypeOfCode());

--- a/src/main/java/com/example/SonamuProject/preprocessor/generated/ErrorNotifierExample.java
+++ b/src/main/java/com/example/SonamuProject/preprocessor/generated/ErrorNotifierExample.java
@@ -1,0 +1,80 @@
+package com.example.SonamuProject.preprocessor.generated;
+
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+
+public class ErrorNotifierExample {
+    public static final class ErrorDelegatingPrintStream extends PrintStream {
+        public ErrorDelegatingPrintStream(PrintStream defaultErr)
+                throws FileNotFoundException, UnsupportedEncodingException {
+            super(defaultErr);
+        }
+
+        @Override
+        public void print(boolean b) {
+            super.print(b);
+            notifyListener(b);
+        }
+
+        @Override
+        public void print(char c) {
+            super.print(c);
+            notifyListener(c);
+        }
+
+        @Override
+        public void print(int i) {
+            super.print(i);
+            notifyListener(i);
+        }
+
+        @Override
+        public void print(long l) {
+            super.print(l);
+            notifyListener(l);
+        }
+
+        @Override
+        public void print(float f) {
+            super.print(f);
+            notifyListener(f);
+        }
+
+        @Override
+        public void print(double d) {
+            super.print(d);
+            notifyListener(d);
+        }
+
+        @Override
+        public void print(char[] s) {
+            super.print(s);
+            notifyListener(s);
+        }
+
+        @Override
+        public void print(String s) {
+            super.print(s);
+            notifyListener(s);
+
+        }
+
+        @Override
+        public void print(Object obj) {
+            super.print(obj);
+            notifyListener(obj);
+
+        }
+
+        @Override
+        public PrintStream append(CharSequence csq, int start, int end) {
+            notifyListener(csq); // TODO will need some special handling
+            return super.append(csq, start, end);
+        }
+
+        private void notifyListener(Object string) {
+            throw new RuntimeException("test");
+        }
+    }
+}


### PR DESCRIPTION
입력 코드(Solidity 또는 소나무)에 파싱 오류가 발생하면
이를 감지한 후 번역을 수행하지 않고 오류 메시지를 출력하도록 함